### PR TITLE
Add support for changes to `conduit::Body`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "conduit-git-http-backend"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -13,5 +13,5 @@ Conduit handler for running `git http-backend` and serving up a git repository.
 """
 
 [dependencies]
-conduit = "0.9.0-alpha.1"
+conduit = { git = "https://github.com/jtgeibel/conduit", rev = "0deff5b" } # "0.9.0-alpha.2"
 flate2 = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ Conduit handler for running `git http-backend` and serving up a git repository.
 """
 
 [dependencies]
-conduit = { git = "https://github.com/jtgeibel/conduit", rev = "0deff5b" } # "0.9.0-alpha.2"
+conduit = "0.9.0-alpha.2"
 flate2 = "1"


### PR DESCRIPTION
This drops the ability to stream the child process stdout via the web server.  Instead, the middleware buffers the entire process output into memory before returning.  This functionality is only used by crates.io when doing local development within a docker container.

r? @JohnTitor
cc conduit-rust/conduit#24