### PR TITLE
Bump MSRV up to 1.49.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   # minimum supported rust version
-  MSRV: 1.46.0
+  MSRV: 1.49.0
   RUSTFLAGS: "-D warnings"
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = """
 Conduit handler for running `git http-backend` and serving up a git repository.
 """
 edition = "2018"
-rust-version = "1.46.0"
+rust-version = "1.49.0"
 
 [dependencies]
 conduit = "0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl Serve {
         let mut headers = HashMap::new();
         for line in rdr.by_ref().lines() {
             let line = line?;
-            if line == "" || line == "\r" {
+            if line.is_empty() || line == "\r" {
                 break;
             }
 


### PR DESCRIPTION
Our dependency requires it: https://github.com/conduit-rust/conduit-git-http-backend/runs/7370548135?check_suite_focus=true

Signed-off-by: Yuki Okushi <jtitor@2k36.org>